### PR TITLE
fix: remove --production flag from bun install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -227,7 +227,7 @@ else
         git config --global --add safe.directory "$BOLT_INSTALL_DIR"
     fi
 
-    cd "$BOLT_INSTALL_DIR" && bun install --production >/dev/null 2>&1
+    cd "$BOLT_INSTALL_DIR" && bun install >/dev/null 2>&1
     printf "   ${GREEN}+${NC} Bolt installed\n"
 
     BUN_BIN=$(command -v bun)


### PR DESCRIPTION
## Summary
- `bun install --production` enforces `--frozen-lockfile` which fails silently when the lockfile has minor version discrepancies
- This causes the install script to abort at step 3/5 (due to `set -e`), never reaching systemd setup or admin token generation
- Fix: use `bun install` without `--production` flag

## Test plan
- [ ] Run `curl -fsSL https://bolt.cyberstrike.io/install.sh | sudo sh` on clean Ubuntu
- [ ] Verify all 5 steps complete and admin token is displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)