### PR TITLE
feat: Ollama + MCP bridge so local models can drive bolt

### DIFF
--- a/.mcphost.json
+++ b/.mcphost.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "bolt": {
+      "type": "remote",
+      "url": "${env://BOLT_URL:-http://localhost:3001/mcp}",
+      "headers": ["Authorization: Bearer ${env://BOLT_ADMIN_TOKEN}"]
+    }
+  }
+}

--- a/Modelfile.qwen14b-bolt
+++ b/Modelfile.qwen14b-bolt
@@ -1,0 +1,6 @@
+FROM qwen2.5:14b
+
+PARAMETER num_ctx 32768
+PARAMETER temperature 0.2
+PARAMETER top_p 0.9
+PARAMETER repeat_penalty 1.05

--- a/Modelfile.qwen7b-bolt
+++ b/Modelfile.qwen7b-bolt
@@ -1,0 +1,6 @@
+FROM qwen2.5:7b
+
+PARAMETER num_ctx 32768
+PARAMETER temperature 0.2
+PARAMETER top_p 0.9
+PARAMETER repeat_penalty 1.05

--- a/bridge-api.py
+++ b/bridge-api.py
@@ -32,7 +32,23 @@ POST /scan body (JSON):
   }
 
 Response 200:
-  { "ok": true, "output": "...", "duration_ms": 12345, "model": "..." }
+  {
+    "ok":          true,
+    "output":      "...final assistant message...",
+    "tool_calls":  [
+      {
+        "seq":    1,
+        "tool":   "bolt__crtsh_crtsh",
+        "args":   "domain:example.com",
+        "status": "ok",                 # or "error"
+        "result": "first ~500 chars of tool output…"
+      },
+      ...
+    ],
+    "duration_ms": 12345,
+    "model":       "qwen2.5:7b-bolt"
+    # if verbose: "raw_transcript": "...full ANSI-stripped mcphost output..."
+  }
 
 Response 4xx/5xx:
   { "ok": false, "error": "..." }
@@ -60,10 +76,138 @@ HOST = os.environ.get("HOST", "0.0.0.0")
 PORT = int(os.environ.get("PORT", "8080"))
 DEFAULT_TIMEOUT = int(os.environ.get("DEFAULT_TIMEOUT", "900"))
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+# mcphost --compact transcript markers:
+#   single-line:   "[ bolt__nmap target:x ] Result <text>"
+#   multi-line:    "[ bolt__nmap target:x"   then later "] Result <text>"
+#   assistant:     "< model <streamed-token-running-buffer>"
+TOOL_FULL_RE  = re.compile(r"^\s*\[\s+(bolt__\S+)\s+(.*?)\s+\]\s+(\S+)\s*(.*?)\s*$")
+TOOL_OPEN_RE  = re.compile(r"^\s*\[\s+(bolt__\S+)\s*(.*?)\s*$")
+TOOL_CLOSE_RE = re.compile(r"^\s*\]\s+(\S+)\s*(.*?)\s*$")
+ASSISTANT_RE  = re.compile(r"^\s*<\s+\S+\s+(.*)$")
+NOISE_RE      = re.compile(r"(Thinking\.\.\.|Executing\s+bolt__\S+\.\.\.|Loading Ollama model\.\.\.)")
+RESULT_PREVIEW_CHARS = 500
 
 
 def strip_ansi(s: str) -> str:
-    return ANSI_RE.sub("", s).replace("\r", "")
+    # mcphost uses bare CR to overwrite the same TUI line per token. Replacing
+    # CR with LF turns each redraw into its own line so the parser can see
+    # markers that would otherwise be glued onto the end of a long spinner row.
+    return ANSI_RE.sub("", s).replace("\r", "\n")
+
+
+def _status_of(kind: str) -> str:
+    return "error" if kind.lower().startswith("err") else "ok"
+
+
+def _is_marker(line: str) -> bool:
+    return bool(TOOL_FULL_RE.match(line) or TOOL_OPEN_RE.match(line)
+                or TOOL_CLOSE_RE.match(line) or ASSISTANT_RE.match(line))
+
+
+def _dewrap(lines: list) -> str:
+    """Join word-wrapped lines from mcphost's TUI back into a single string.
+    Heuristic: a line that ends with a hyphen followed by a line that starts
+    with lowercase letters is a wrap split — fuse them. Otherwise keep the
+    newline (preserves intentional markdown breaks).
+    """
+    if not lines:
+        return ""
+    out = [lines[0]]
+    for nxt in lines[1:]:
+        prev = out[-1]
+        if prev.endswith("-") and nxt and nxt[0].islower():
+            out[-1] = prev[:-1] + nxt        # fuse: "hello-from-" + "bridge"
+        elif prev and not prev.endswith((".", "!", "?", ":", ";", ",", ")", "]", "}", "*", "`")) \
+                and nxt and nxt[0].islower():
+            out[-1] = prev + " " + nxt        # fuse: "responded with" + "hello"
+        else:
+            out.append(nxt)
+    return "\n".join(out).strip()
+
+
+def parse_mcphost_output(raw: str) -> Tuple[str, list, str]:
+    """Walk mcphost's --compact transcript and pull out:
+      - final assistant message (str)
+      - structured list of tool calls
+      - cleaned-up transcript (noise stripped) for verbose mode
+
+    Real-world quirks handled:
+      - mcphost token-streams assistant messages: each "< model …" line
+        is a re-print of the running buffer.
+      - the running buffer is word-wrapped to terminal width, so any frame
+        spans multiple raw lines — the trailing lines have NO "<" prefix.
+      - fast tools render open + close on a SINGLE line ("[ … ] Result …").
+    """
+    text = strip_ansi(raw)
+    cleaned_lines = [l.rstrip() for l in text.split("\n") if not NOISE_RE.search(l)]
+    cleaned = "\n".join(cleaned_lines)
+
+    # ---- pass 1: tool_calls (also reset on each new "<") ----
+    tool_calls: list = []
+    state = "idle"
+    cur: Optional[dict] = None
+    seq = 0
+    for line in cleaned_lines:
+        m = TOOL_FULL_RE.match(line)
+        if m:
+            seq += 1
+            tc = {"seq": seq, "tool": m.group(1), "args": m.group(2).strip(),
+                  "status": _status_of(m.group(3)), "result": m.group(4).strip()}
+            tool_calls.append(tc)
+            cur = tc; state = "tool_result"; continue
+        m = TOOL_OPEN_RE.match(line)
+        if m and "]" not in line:
+            seq += 1
+            cur = {"seq": seq, "tool": m.group(1), "args": m.group(2).strip(),
+                   "status": "pending", "result": ""}
+            tool_calls.append(cur)
+            state = "tool_open"; continue
+        m = TOOL_CLOSE_RE.match(line)
+        if m and cur is not None and state in ("tool_open", "tool_result"):
+            cur["status"] = _status_of(m.group(1))
+            extra = m.group(2).strip()
+            cur["result"] = (cur["result"] + " " + extra).strip() if cur["result"] else extra
+            state = "tool_result"; continue
+        if ASSISTANT_RE.match(line):
+            state = "assistant"; cur = None; continue
+        bare = line.strip()
+        if not bare:
+            continue
+        if state == "tool_open" and cur is not None:
+            cur["args"] = (cur["args"] + " " + bare).strip()
+        elif state == "tool_result" and cur is not None:
+            cur["result"] = (cur["result"] + " " + bare).strip()
+
+    # ---- pass 2: final assistant message ----
+    # Walk from the end backwards; the LAST "<" line is the start of the
+    # final streamed frame. Everything after it (until the next marker, which
+    # there shouldn't be) is wrap continuation of that same frame.
+    final_message = ""
+    last_idx = None
+    for i in range(len(cleaned_lines) - 1, -1, -1):
+        if ASSISTANT_RE.match(cleaned_lines[i]):
+            last_idx = i
+            break
+    if last_idx is not None:
+        m = ASSISTANT_RE.match(cleaned_lines[last_idx])
+        parts = [m.group(1).rstrip()]
+        for j in range(last_idx + 1, len(cleaned_lines)):
+            ln = cleaned_lines[j]
+            if _is_marker(ln):
+                break
+            stripped = ln.strip()
+            if stripped:
+                parts.append(stripped)
+            elif parts and parts[-1]:
+                parts.append("")  # preserve paragraph breaks
+        final_message = _dewrap(parts)
+
+    # truncate giant tool results so the response stays sane
+    for c in tool_calls:
+        if len(c["result"]) > RESULT_PREVIEW_CHARS:
+            c["result"] = c["result"][:RESULT_PREVIEW_CHARS] + "…"
+
+    return final_message, tool_calls, cleaned.strip()
 
 
 def build_prompt(body: dict) -> str:
@@ -101,7 +245,7 @@ def build_prompt(body: dict) -> str:
 
 def run_bridge(prompt: str, model: Optional[str], max_steps: Optional[int],
                verbose: bool, timeout: int,
-               system_prompt: Optional[str]) -> Tuple[bool, str, int, str]:
+               system_prompt: Optional[str]) -> Tuple[bool, str, int, str, list, str]:
     env = os.environ.copy()
     if model:
         env["MODEL"] = model
@@ -119,9 +263,9 @@ def run_bridge(prompt: str, model: Optional[str], max_steps: Optional[int],
         sp_file.close()
         env["SYSTEM_PROMPT"] = sp_file.name
 
+    # We always capture the full transcript so we can extract tool_calls.
+    # `verbose` controls only whether the raw transcript is returned to the client.
     cmd = [BRIDGE, "--compact", "-p", prompt]
-    if not verbose:
-        cmd.append("--quiet")
 
     started = time.monotonic()
     try:
@@ -132,17 +276,17 @@ def run_bridge(prompt: str, model: Optional[str], max_steps: Optional[int],
     except subprocess.TimeoutExpired:
         if sp_file:
             os.unlink(sp_file.name)
-        return False, "", int((time.monotonic() - started) * 1000), f"timeout after {timeout}s"
+        return False, "", int((time.monotonic() - started) * 1000), f"timeout after {timeout}s", [], ""
     finally:
         if sp_file and os.path.exists(sp_file.name):
             os.unlink(sp_file.name)
 
     duration_ms = int((time.monotonic() - started) * 1000)
-    out = strip_ansi(proc.stdout).strip()
+    final, tool_calls, transcript = parse_mcphost_output(proc.stdout)
     err = strip_ansi(proc.stderr).strip()
     if proc.returncode != 0:
-        return False, out, duration_ms, err or f"exit {proc.returncode}"
-    return True, out, duration_ms, ""
+        return False, final, duration_ms, err or f"exit {proc.returncode}", tool_calls, transcript
+    return True, final, duration_ms, "", tool_calls, transcript
 
 
 def health() -> Tuple[bool, dict]:
@@ -197,20 +341,26 @@ class H(BaseHTTPRequestHandler):
 
         prompt = raw_prompt or build_prompt(body)
         timeout = int(body.get("timeout") or DEFAULT_TIMEOUT)
-        ok, out, ms, err = run_bridge(
+        verbose = bool(body.get("verbose", False))
+        ok, out, ms, err, tool_calls, transcript = run_bridge(
             prompt=prompt,
             model=body.get("model"),
             max_steps=body.get("max_steps"),
-            verbose=bool(body.get("verbose", False)),
+            verbose=verbose,
             timeout=timeout,
             system_prompt=body.get("system_prompt"),
         )
-        return self._json(
-            200 if ok else 500,
-            {"ok": ok, "output": out, "duration_ms": ms,
-             "model": body.get("model") or os.environ.get("MODEL", "default"),
-             "error": err if not ok else None},
-        )
+        resp = {
+            "ok": ok,
+            "output": out,
+            "tool_calls": tool_calls,
+            "duration_ms": ms,
+            "model": body.get("model") or os.environ.get("MODEL", "default"),
+            "error": err if not ok else None,
+        }
+        if verbose:
+            resp["raw_transcript"] = transcript
+        return self._json(200 if ok else 500, resp)
 
 
 def main():

--- a/bridge-api.py
+++ b/bridge-api.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+HTTP wrapper around ollama-bridge.sh.
+
+Endpoints:
+  GET  /health          quick reachability check (ollama + bolt + bridge script)
+  POST /scan            run a recon job, return final assistant answer
+
+POST /scan body (JSON):
+  {
+    # User prompt — provide ONE of:
+    "prompt":        "Recon acme.com end-to-end…",   # raw, used verbatim
+    # OR auto-build from these fields:
+    "target":       "acme.com",                      # required if 'prompt' not set.
+                                                     # String form, for tools whose schema takes
+                                                     # a single host (nmap, httpx, sslscan, ...).
+    "targets":      ["acme.com", "api.acme.com"],    # optional. Array form, for tools that
+                                                     # accept a list (mass nuclei, batch httpx).
+                                                     # If both 'target' and 'targets' are given,
+                                                     # both are surfaced in the prompt — the model
+                                                     # picks the right shape per tool.
+    "iocs":         ["1.2.3.4", "evil.example.com"], # optional
+    "infra":        "AWS account 123456, primary domain acme.com, ASN 12345",
+    "instructions": "focus on subdomain takeover risk",
+
+    # Optional overrides for this request only:
+    "system_prompt": "You are a CVE triage analyst…",   # full text; overrides agent role
+    "model":         "qwen2.5:7b-bolt",
+    "max_steps":     30,
+    "timeout":       900,                            # seconds, default 900 (15 min)
+    "verbose":       false                           # include tool-call trace?
+  }
+
+Response 200:
+  { "ok": true, "output": "...", "duration_ms": 12345, "model": "..." }
+
+Response 4xx/5xx:
+  { "ok": false, "error": "..." }
+
+Run:
+  python3 bridge-api.py                # listens on 0.0.0.0:8080
+  PORT=9000 HOST=127.0.0.1 python3 bridge-api.py
+
+Stdlib only. No extra deps.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Optional, Tuple
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BRIDGE = os.path.join(HERE, "ollama-bridge.sh")
+HOST = os.environ.get("HOST", "0.0.0.0")
+PORT = int(os.environ.get("PORT", "8080"))
+DEFAULT_TIMEOUT = int(os.environ.get("DEFAULT_TIMEOUT", "900"))
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+
+
+def strip_ansi(s: str) -> str:
+    return ANSI_RE.sub("", s).replace("\r", "")
+
+
+def build_prompt(body: dict) -> str:
+    target = (body.get("target") or "").strip()
+    targets = body.get("targets") or []
+    if isinstance(targets, list):
+        targets = [str(t).strip() for t in targets if str(t).strip()]
+    else:
+        targets = []
+    iocs = body.get("iocs") or []
+    infra = (body.get("infra") or "").strip()
+    extra = (body.get("instructions") or "").strip()
+
+    parts = []
+    if target:
+        parts.append(f"Target (single host, string form): {target}")
+    if targets:
+        parts.append("Targets (list form, JSON array): " + json.dumps(targets))
+    if target and targets:
+        parts.append(
+            "Note: when calling a tool whose schema takes a single host "
+            "(e.g. nmap, httpx, sslscan, nuclei), pass the string form. "
+            "When calling a tool whose schema takes a list, pass the array form. "
+            "Match the tool's parameter type — do not coerce."
+        )
+    if iocs:
+        parts.append("IoCs: " + ", ".join(str(i) for i in iocs))
+    if infra:
+        parts.append(f"Infrastructure context: {infra}")
+    if extra:
+        parts.append(f"Additional instructions: {extra}")
+    parts.append("Recon this target now. Begin with a tool call.")
+    return "\n".join(parts)
+
+
+def run_bridge(prompt: str, model: Optional[str], max_steps: Optional[int],
+               verbose: bool, timeout: int,
+               system_prompt: Optional[str]) -> Tuple[bool, str, int, str]:
+    env = os.environ.copy()
+    if model:
+        env["MODEL"] = model
+    if max_steps is not None:
+        env["MAX_STEPS"] = str(max_steps)
+
+    sp_file = None
+    if system_prompt:
+        # Write to tempfile so we don't hit env-var size limits and so
+        # mcphost reads it as a file (it accepts text or path; file is safer).
+        sp_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", delete=False, encoding="utf-8")
+        sp_file.write(system_prompt)
+        sp_file.flush()
+        sp_file.close()
+        env["SYSTEM_PROMPT"] = sp_file.name
+
+    cmd = [BRIDGE, "--compact", "-p", prompt]
+    if not verbose:
+        cmd.append("--quiet")
+
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(
+            cmd, env=env, capture_output=True, text=True,
+            timeout=timeout, check=False,
+        )
+    except subprocess.TimeoutExpired:
+        if sp_file:
+            os.unlink(sp_file.name)
+        return False, "", int((time.monotonic() - started) * 1000), f"timeout after {timeout}s"
+    finally:
+        if sp_file and os.path.exists(sp_file.name):
+            os.unlink(sp_file.name)
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    out = strip_ansi(proc.stdout).strip()
+    err = strip_ansi(proc.stderr).strip()
+    if proc.returncode != 0:
+        return False, out, duration_ms, err or f"exit {proc.returncode}"
+    return True, out, duration_ms, ""
+
+
+def health() -> Tuple[bool, dict]:
+    checks = {}
+    try:
+        urllib.request.urlopen("http://localhost:11434/api/tags", timeout=3).read()
+        checks["ollama"] = "ok"
+    except Exception as e:
+        checks["ollama"] = f"unreachable: {e}"
+    try:
+        urllib.request.urlopen("http://localhost:3001/health", timeout=3).read()
+        checks["bolt"] = "ok"
+    except Exception as e:
+        checks["bolt"] = f"unreachable: {e}"
+    checks["bridge_script"] = "ok" if os.access(BRIDGE, os.X_OK) else f"missing/not-executable: {BRIDGE}"
+    ok = all(v == "ok" for v in checks.values())
+    return ok, checks
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        sys.stderr.write(f"[{time.strftime('%H:%M:%S')}] {self.address_string()} {fmt % args}\n")
+
+    def _json(self, status: int, body: dict):
+        payload = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self):
+        if self.path == "/health":
+            ok, checks = health()
+            return self._json(200 if ok else 503, {"ok": ok, "checks": checks})
+        return self._json(404, {"ok": False, "error": "not found"})
+
+    def do_POST(self):
+        if self.path != "/scan":
+            return self._json(404, {"ok": False, "error": "not found"})
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(length) or b"{}")
+        except Exception as e:
+            return self._json(400, {"ok": False, "error": f"bad json: {e}"})
+        if "targets" in body and not isinstance(body["targets"], list):
+            return self._json(400, {"ok": False, "error": "'targets' must be an array of strings"})
+        raw_prompt = (body.get("prompt") or "").strip()
+        has_targets = isinstance(body.get("targets"), list) and len(body["targets"]) > 0
+        if not raw_prompt and not body.get("target") and not has_targets:
+            return self._json(400, {"ok": False, "error": "either 'prompt', 'target', or 'targets' is required"})
+
+        prompt = raw_prompt or build_prompt(body)
+        timeout = int(body.get("timeout") or DEFAULT_TIMEOUT)
+        ok, out, ms, err = run_bridge(
+            prompt=prompt,
+            model=body.get("model"),
+            max_steps=body.get("max_steps"),
+            verbose=bool(body.get("verbose", False)),
+            timeout=timeout,
+            system_prompt=body.get("system_prompt"),
+        )
+        return self._json(
+            200 if ok else 500,
+            {"ok": ok, "output": out, "duration_ms": ms,
+             "model": body.get("model") or os.environ.get("MODEL", "default"),
+             "error": err if not ok else None},
+        )
+
+
+def main():
+    if not os.access(BRIDGE, os.X_OK):
+        sys.exit(f"error: {BRIDGE} not found or not executable")
+    srv = ThreadingHTTPServer((HOST, PORT), H)
+    print(f"bridge-api listening on http://{HOST}:{PORT}", flush=True)
+    print(f"  POST /scan  – run a recon job", flush=True)
+    print(f"  GET  /health – reachability check", flush=True)
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/bridge-api.py
+++ b/bridge-api.py
@@ -4,7 +4,14 @@ HTTP wrapper around ollama-bridge.sh.
 
 Endpoints:
   GET  /health          quick reachability check (ollama + bolt + bridge script)
-  POST /scan            run a recon job, return final assistant answer
+  POST /scan            run a recon job, return final assistant answer (sync)
+  POST /scan/stream     same body as /scan, returns NDJSON event stream:
+                          {type:"start",        ts_ms, model}
+                          {type:"tool_start",   ts_ms, seq, tool, args}
+                          {type:"tool_end",     ts_ms, seq, status, result}
+                          {type:"final",        ts_ms, ok, output, tool_calls,
+                                                 duration_ms, exit_code}
+                          {type:"error",        ts_ms, message}
 
 POST /scan body (JSON):
   {
@@ -62,13 +69,14 @@ Stdlib only. No extra deps.
 import json
 import os
 import re
+import select
 import subprocess
 import sys
 import tempfile
 import time
 import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Optional, Tuple
+from typing import Iterator, Optional, Tuple
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 BRIDGE = os.path.join(HERE, "ollama-bridge.sh")
@@ -210,6 +218,200 @@ def parse_mcphost_output(raw: str) -> Tuple[str, list, str]:
     return final_message, tool_calls, cleaned.strip()
 
 
+class StreamingParser:
+    """Incremental version of parse_mcphost_output. Feed it one logical line at
+    a time (lines split on both \\r and \\n so TUI redraws don't glue markers
+    together) and it yields events as state transitions occur.
+
+    tool_end is DEFERRED until the next marker so the result field carries
+    the complete output, not a half-arrived prefix.
+    """
+
+    def __init__(self) -> None:
+        self.tool_calls: list = []
+        self.cur: Optional[dict] = None     # tool whose tool_end has not been emitted yet
+        self.state = "idle"                 # idle | tool_open | tool_result | assistant
+        self.seq = 0
+        self.last_assistant = ""
+
+    def _flush_pending_end(self) -> list:
+        if self.cur and self.cur["status"] != "pending":
+            r = self.cur["result"]
+            preview = (r[:RESULT_PREVIEW_CHARS] + "…") if len(r) > RESULT_PREVIEW_CHARS else r
+            ev = {"type": "tool_end", "seq": self.cur["seq"],
+                  "status": self.cur["status"], "result": preview}
+            self.cur = None
+            return [ev]
+        return []
+
+    def feed(self, raw_line: str) -> list:
+        line = strip_ansi(raw_line).rstrip()
+        if not line or NOISE_RE.search(line):
+            return []
+        events: list = []
+
+        m = TOOL_FULL_RE.match(line)
+        if m:
+            events.extend(self._flush_pending_end())
+            self.seq += 1
+            tc = {"seq": self.seq, "tool": m.group(1), "args": m.group(2).strip(),
+                  "status": _status_of(m.group(3)), "result": m.group(4).strip()}
+            self.tool_calls.append(tc)
+            self.cur = tc
+            self.state = "tool_result"
+            events.append({"type": "tool_start", "seq": tc["seq"],
+                           "tool": tc["tool"], "args": tc["args"]})
+            return events
+
+        m = TOOL_OPEN_RE.match(line)
+        if m and "]" not in line:
+            events.extend(self._flush_pending_end())
+            self.seq += 1
+            self.cur = {"seq": self.seq, "tool": m.group(1), "args": m.group(2).strip(),
+                        "status": "pending", "result": ""}
+            self.tool_calls.append(self.cur)
+            self.state = "tool_open"
+            events.append({"type": "tool_start", "seq": self.cur["seq"],
+                           "tool": self.cur["tool"], "args": self.cur["args"]})
+            return events
+
+        m = TOOL_CLOSE_RE.match(line)
+        if m and self.cur is not None and self.state in ("tool_open", "tool_result"):
+            self.cur["status"] = _status_of(m.group(1))
+            extra = m.group(2).strip()
+            self.cur["result"] = (self.cur["result"] + " " + extra).strip() if self.cur["result"] else extra
+            self.state = "tool_result"
+            return events  # tool_end deferred until next marker
+
+        m = ASSISTANT_RE.match(line)
+        if m:
+            events.extend(self._flush_pending_end())
+            self.last_assistant = m.group(1).strip()
+            self.state = "assistant"
+            return events
+
+        bare = line.strip()
+        if not bare:
+            return events
+        if self.state == "tool_open" and self.cur is not None:
+            self.cur["args"] = (self.cur["args"] + " " + bare).strip()
+        elif self.state == "tool_result" and self.cur is not None:
+            self.cur["result"] = (self.cur["result"] + " " + bare).strip()
+        # assistant continuation lines belong to the running buffer; the next
+        # "<" frame will carry the full snapshot, so we don't append here.
+        return events
+
+    def flush(self) -> list:
+        return self._flush_pending_end()
+
+
+def run_bridge_stream(prompt: str, model: Optional[str], max_steps: Optional[int],
+                      timeout: int, system_prompt: Optional[str]) -> Iterator[bytes]:
+    """Spawn mcphost and yield NDJSON-encoded events as bytes. The HTTP handler
+    writes each yielded chunk straight to the wire and flushes — that's the
+    streaming behavior the caller sees.
+    """
+    env = os.environ.copy()
+    if model:
+        env["MODEL"] = model
+    if max_steps is not None:
+        env["MAX_STEPS"] = str(max_steps)
+
+    sp_file = None
+    if system_prompt:
+        sp_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", delete=False, encoding="utf-8")
+        sp_file.write(system_prompt)
+        sp_file.flush()
+        sp_file.close()
+        env["SYSTEM_PROMPT"] = sp_file.name
+
+    cmd = [BRIDGE, "--compact", "-p", prompt]
+    started = time.monotonic()
+
+    def encode(ev: dict) -> bytes:
+        ev.setdefault("ts_ms", int((time.monotonic() - started) * 1000))
+        return (json.dumps(ev) + "\n").encode("utf-8")
+
+    yield encode({"type": "start",
+                  "model": model or os.environ.get("MODEL", "default")})
+
+    parser = StreamingParser()
+    proc: Optional[subprocess.Popen] = None
+    try:
+        proc = subprocess.Popen(
+            cmd, env=env,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            bufsize=0,
+        )
+        fd = proc.stdout.fileno()
+        deadline = started + timeout
+        buf = b""
+
+        while True:
+            if time.monotonic() > deadline:
+                proc.terminate()
+                yield encode({"type": "error",
+                              "message": f"timeout after {timeout}s"})
+                return
+            rlist, _, _ = select.select([fd], [], [], 0.5)
+            if not rlist:
+                if proc.poll() is not None:
+                    break
+                continue
+            try:
+                chunk = os.read(fd, 4096)
+            except OSError:
+                break
+            if not chunk:
+                break
+            buf += chunk
+            text = buf.decode("utf-8", errors="replace")
+            parts = re.split(r"[\r\n]+", text)
+            buf = parts[-1].encode("utf-8")
+            for line in parts[:-1]:
+                for ev in parser.feed(line):
+                    yield encode(ev)
+
+        # drain any trailing partial line
+        tail = buf.decode("utf-8", errors="replace")
+        if tail.strip():
+            for ev in parser.feed(tail):
+                yield encode(ev)
+        for ev in parser.flush():
+            yield encode(ev)
+
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    finally:
+        if proc and proc.poll() is None:
+            try:
+                proc.terminate()
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        if sp_file and os.path.exists(sp_file.name):
+            try:
+                os.unlink(sp_file.name)
+            except OSError:
+                pass
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    for c in parser.tool_calls:
+        if len(c["result"]) > RESULT_PREVIEW_CHARS:
+            c["result"] = c["result"][:RESULT_PREVIEW_CHARS] + "…"
+    yield encode({
+        "type": "final",
+        "ok": (proc.returncode == 0) if proc else False,
+        "output": parser.last_assistant.strip(),
+        "tool_calls": parser.tool_calls,
+        "duration_ms": duration_ms,
+        "exit_code": proc.returncode if proc else None,
+    })
+
+
 def build_prompt(body: dict) -> str:
     target = (body.get("target") or "").strip()
     targets = body.get("targets") or []
@@ -324,23 +526,38 @@ class H(BaseHTTPRequestHandler):
             return self._json(200 if ok else 503, {"ok": ok, "checks": checks})
         return self._json(404, {"ok": False, "error": "not found"})
 
-    def do_POST(self):
-        if self.path != "/scan":
-            return self._json(404, {"ok": False, "error": "not found"})
+    def _read_and_validate_body(self):
+        """Returns (body, prompt, timeout) or sends an error and returns None."""
         try:
             length = int(self.headers.get("Content-Length", 0))
             body = json.loads(self.rfile.read(length) or b"{}")
         except Exception as e:
-            return self._json(400, {"ok": False, "error": f"bad json: {e}"})
+            self._json(400, {"ok": False, "error": f"bad json: {e}"})
+            return None
         if "targets" in body and not isinstance(body["targets"], list):
-            return self._json(400, {"ok": False, "error": "'targets' must be an array of strings"})
+            self._json(400, {"ok": False, "error": "'targets' must be an array of strings"})
+            return None
         raw_prompt = (body.get("prompt") or "").strip()
         has_targets = isinstance(body.get("targets"), list) and len(body["targets"]) > 0
         if not raw_prompt and not body.get("target") and not has_targets:
-            return self._json(400, {"ok": False, "error": "either 'prompt', 'target', or 'targets' is required"})
-
+            self._json(400, {"ok": False, "error": "either 'prompt', 'target', or 'targets' is required"})
+            return None
         prompt = raw_prompt or build_prompt(body)
         timeout = int(body.get("timeout") or DEFAULT_TIMEOUT)
+        return body, prompt, timeout
+
+    def do_POST(self):
+        if self.path == "/scan":
+            return self._handle_scan()
+        if self.path == "/scan/stream":
+            return self._handle_scan_stream()
+        return self._json(404, {"ok": False, "error": "not found"})
+
+    def _handle_scan(self):
+        parsed = self._read_and_validate_body()
+        if parsed is None:
+            return
+        body, prompt, timeout = parsed
         verbose = bool(body.get("verbose", False))
         ok, out, ms, err, tool_calls, transcript = run_bridge(
             prompt=prompt,
@@ -362,14 +579,46 @@ class H(BaseHTTPRequestHandler):
             resp["raw_transcript"] = transcript
         return self._json(200 if ok else 500, resp)
 
+    def _handle_scan_stream(self):
+        parsed = self._read_and_validate_body()
+        if parsed is None:
+            return
+        body, prompt, timeout = parsed
+
+        # NDJSON stream — clients read line-by-line until the connection closes.
+        # No Content-Length so the server keeps writing until run_bridge_stream
+        # finishes; Connection: close tells the client EOF == done.
+        self.send_response(200)
+        self.send_header("Content-Type", "application/x-ndjson")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "close")
+        self.send_header("X-Accel-Buffering", "no")  # disable proxy buffering
+        self.end_headers()
+
+        try:
+            for chunk in run_bridge_stream(
+                prompt=prompt,
+                model=body.get("model"),
+                max_steps=body.get("max_steps"),
+                timeout=timeout,
+                system_prompt=body.get("system_prompt"),
+            ):
+                self.wfile.write(chunk)
+                self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            # Client gave up. The subprocess gets killed by run_bridge_stream's
+            # finally block when this generator is GC'd.
+            pass
+
 
 def main():
     if not os.access(BRIDGE, os.X_OK):
         sys.exit(f"error: {BRIDGE} not found or not executable")
     srv = ThreadingHTTPServer((HOST, PORT), H)
     print(f"bridge-api listening on http://{HOST}:{PORT}", flush=True)
-    print(f"  POST /scan  – run a recon job", flush=True)
-    print(f"  GET  /health – reachability check", flush=True)
+    print(f"  POST /scan         – run a recon job (sync, returns final JSON)", flush=True)
+    print(f"  POST /scan/stream  – same body, NDJSON event stream", flush=True)
+    print(f"  GET  /health       – reachability check", flush=True)
     try:
         srv.serve_forever()
     except KeyboardInterrupt:

--- a/bridge-api.py
+++ b/bridge-api.py
@@ -428,20 +428,26 @@ def build_prompt(body: dict) -> str:
         parts.append(f"Target (single host, string form): {target}")
     if targets:
         parts.append("Targets (list form, JSON array): " + json.dumps(targets))
-    if target and targets:
-        parts.append(
-            "Note: when calling a tool whose schema takes a single host "
-            "(e.g. nmap, httpx, sslscan, nuclei), pass the string form. "
-            "When calling a tool whose schema takes a list, pass the array form. "
-            "Match the tool's parameter type — do not coerce."
-        )
+    # Always include the type guidance — the model needs it on every request,
+    # not only when the caller happens to set both fields.
+    parts.append(
+        "When calling a tool whose schema takes a single host "
+        "(nmap, httpx, sslscan, nuclei, wpscan, http-headers), pass a STRING. "
+        "When calling a tool whose schema takes a list (dnsx_resolve.hosts), "
+        "pass an ARRAY. Match the schema exactly — do not coerce."
+    )
     if iocs:
         parts.append("IoCs: " + ", ".join(str(i) for i in iocs))
     if infra:
         parts.append(f"Infrastructure context: {infra}")
     if extra:
         parts.append(f"Additional instructions: {extra}")
-    parts.append("Recon this target now. Begin with a tool call.")
+    parts.append(
+        "Begin the engagement now. Your first message must be a tool call. "
+        "Run the full pipeline for this target's branch (enumerate → resolve "
+        "→ probe → vuln-scan), not just enumeration. Do not stop after the "
+        "first phase."
+    )
     return "\n".join(parts)
 
 

--- a/bridge-api.py
+++ b/bridge-api.py
@@ -66,6 +66,7 @@ Run:
 
 Stdlib only. No extra deps.
 """
+import ipaddress
 import json
 import os
 import re
@@ -76,13 +77,80 @@ import tempfile
 import time
 import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Iterator, Optional, Tuple
+from typing import Iterator, List, Optional, Tuple
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 BRIDGE = os.path.join(HERE, "ollama-bridge.sh")
+SCOPE_FILE = os.environ.get("SCOPE_FILE", os.path.join(HERE, "scope.json"))
 HOST = os.environ.get("HOST", "0.0.0.0")
 PORT = int(os.environ.get("PORT", "8080"))
 DEFAULT_TIMEOUT = int(os.environ.get("DEFAULT_TIMEOUT", "900"))
+
+
+def _load_scope() -> dict:
+    """Load scope.json once at startup. Missing/empty rules => scope checks
+    are skipped (dev-friendly). Compiled patterns/networks are cached.
+    """
+    out = {
+        "domain_patterns": [],   # list[re.Pattern]
+        "cidrs": [],             # list[ipaddress.ip_network]
+        "disabled_tools": [],    # list[str]
+        "active": False,
+    }
+    if not os.path.exists(SCOPE_FILE):
+        return out
+    try:
+        with open(SCOPE_FILE, encoding="utf-8") as f:
+            cfg = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        sys.stderr.write(f"warning: could not read {SCOPE_FILE}: {e}\n")
+        return out
+    for p in cfg.get("allowed_domain_patterns") or []:
+        try:
+            out["domain_patterns"].append(re.compile(p, re.IGNORECASE))
+        except re.error as e:
+            sys.stderr.write(f"warning: bad regex {p!r}: {e}\n")
+    for c in cfg.get("allowed_cidrs") or []:
+        try:
+            out["cidrs"].append(ipaddress.ip_network(c, strict=False))
+        except ValueError as e:
+            sys.stderr.write(f"warning: bad cidr {c!r}: {e}\n")
+    for t in cfg.get("disabled_tools") or []:
+        if isinstance(t, str) and t.strip():
+            out["disabled_tools"].append(t.strip())
+    out["active"] = bool(out["domain_patterns"] or out["cidrs"])
+    return out
+
+
+SCOPE = _load_scope()
+
+
+def _target_in_scope(t: str) -> bool:
+    """Return True iff t matches any allowed domain pattern OR falls inside
+    any allowed CIDR. When scope is inactive (no rules), everything is allowed.
+    """
+    if not SCOPE["active"]:
+        return True
+    if not t:
+        return False
+    s = t.strip()
+    # Strip scheme/path so we can match the hostname or IP.
+    s = re.sub(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", "", s)   # scheme
+    s = s.split("/", 1)[0]                              # path
+    s = s.split("?", 1)[0]
+    host = s.split(":", 1)[0]                           # port
+    # IP / CIDR check
+    try:
+        ip = ipaddress.ip_address(host)
+        return any(ip in net for net in SCOPE["cidrs"])
+    except ValueError:
+        pass
+    # Domain regex check
+    return any(p.fullmatch(host) or p.search(host) for p in SCOPE["domain_patterns"])
+
+
+def _out_of_scope(targets: List[str]) -> List[str]:
+    return [t for t in targets if not _target_in_scope(t)]
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
 # mcphost --compact transcript markers:
 #   single-line:   "[ bolt__nmap target:x ] Result <text>"
@@ -442,6 +510,13 @@ def build_prompt(body: dict) -> str:
         parts.append(f"Infrastructure context: {infra}")
     if extra:
         parts.append(f"Additional instructions: {extra}")
+    if SCOPE["disabled_tools"]:
+        parts.append(
+            "DISABLED tools for this engagement (must NOT be called under "
+            "any circumstances; if you need their capability, pick a "
+            "different tool or report the gap in the final summary): "
+            + ", ".join(SCOPE["disabled_tools"])
+        )
     parts.append(
         "Begin the engagement now. Your first message must be a tool call. "
         "Run the full pipeline for this target's branch (enumerate → resolve "
@@ -548,6 +623,25 @@ class H(BaseHTTPRequestHandler):
         if not raw_prompt and not body.get("target") and not has_targets:
             self._json(400, {"ok": False, "error": "either 'prompt', 'target', or 'targets' is required"})
             return None
+
+        # Scope enforcement. When SCOPE["active"] is False (no rules loaded)
+        # this is a no-op. When active, every explicit target/targets entry
+        # must be in-scope. Raw `prompt`-only requests are allowed through
+        # because we can't reliably extract targets from free text — Rails
+        # callers SHOULD prefer structured fields when scope matters.
+        if SCOPE["active"]:
+            to_check = []
+            if body.get("target"):
+                to_check.append(str(body["target"]).strip())
+            if has_targets:
+                to_check.extend(str(t).strip() for t in body["targets"])
+            bad = _out_of_scope(to_check)
+            if bad:
+                self._json(403, {"ok": False,
+                                 "error": "target out of scope",
+                                 "out_of_scope": bad})
+                return None
+
         prompt = raw_prompt or build_prompt(body)
         timeout = int(body.get("timeout") or DEFAULT_TIMEOUT)
         return body, prompt, timeout
@@ -625,6 +719,13 @@ def main():
     print(f"  POST /scan         – run a recon job (sync, returns final JSON)", flush=True)
     print(f"  POST /scan/stream  – same body, NDJSON event stream", flush=True)
     print(f"  GET  /health       – reachability check", flush=True)
+    if SCOPE["active"]:
+        print(f"scope: {SCOPE_FILE} — "
+              f"{len(SCOPE['domain_patterns'])} domain rule(s), "
+              f"{len(SCOPE['cidrs'])} CIDR(s), "
+              f"{len(SCOPE['disabled_tools'])} disabled tool(s)", flush=True)
+    else:
+        print(f"scope: DISABLED (no {SCOPE_FILE} or empty rules) — all targets allowed", flush=True)
     try:
         srv.serve_forever()
     except KeyboardInterrupt:

--- a/ollama-bridge.sh
+++ b/ollama-bridge.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Bridge Ollama -> bolt MCP via mcphost.
+# Usage:
+#   ./ollama-bridge.sh                          # interactive chat with default model
+#   ./ollama-bridge.sh -p "scan example.com"    # one-shot prompt
+#   MODEL=qwen2.5:7b ./ollama-bridge.sh         # override Ollama model
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODEL="${MODEL:-qwen2.5:7b-bolt}"
+BOLT_CONTAINER="${BOLT_CONTAINER:-bolt}"
+BOLT_URL="${BOLT_URL:-http://localhost:3001/mcp}"
+SYSTEM_PROMPT="${SYSTEM_PROMPT:-$DIR/prompts/recon-agent.md}"
+MAX_STEPS="${MAX_STEPS:-30}"
+TEMPERATURE="${TEMPERATURE:-0.2}"
+
+if [ -z "${BOLT_ADMIN_TOKEN:-}" ]; then
+  if ! docker ps --format '{{.Names}}' | grep -qx "$BOLT_CONTAINER"; then
+    echo "error: bolt container '$BOLT_CONTAINER' not running. start it first." >&2
+    exit 1
+  fi
+  BOLT_ADMIN_TOKEN="$(docker exec "$BOLT_CONTAINER" printenv MCP_ADMIN_TOKEN)"
+fi
+
+if ! curl -fsS -o /dev/null "${BOLT_URL%/mcp}/health"; then
+  echo "error: bolt health check failed at ${BOLT_URL%/mcp}/health" >&2
+  exit 1
+fi
+
+if ! curl -fsS http://localhost:11434/api/tags >/dev/null; then
+  echo "error: ollama not reachable at http://localhost:11434" >&2
+  exit 1
+fi
+
+export BOLT_ADMIN_TOKEN BOLT_URL
+exec mcphost \
+  --config "$DIR/.mcphost.json" \
+  --model "ollama:$MODEL" \
+  --system-prompt "$SYSTEM_PROMPT" \
+  --max-steps "$MAX_STEPS" \
+  --temperature "$TEMPERATURE" \
+  "$@"

--- a/ollama-bridge.sh
+++ b/ollama-bridge.sh
@@ -11,7 +11,7 @@ MODEL="${MODEL:-qwen2.5:7b-bolt}"
 BOLT_CONTAINER="${BOLT_CONTAINER:-bolt}"
 BOLT_URL="${BOLT_URL:-http://localhost:3001/mcp}"
 SYSTEM_PROMPT="${SYSTEM_PROMPT:-$DIR/prompts/recon-agent.md}"
-MAX_STEPS="${MAX_STEPS:-30}"
+MAX_STEPS="${MAX_STEPS:-50}"
 TEMPERATURE="${TEMPERATURE:-0.2}"
 
 if [ -z "${BOLT_ADMIN_TOKEN:-}" ]; then

--- a/ollama-bridge.sh
+++ b/ollama-bridge.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MODEL="${MODEL:-qwen2.5:7b-bolt}"
+MODEL="${MODEL:-qwen2.5:14b-bolt}"
 BOLT_CONTAINER="${BOLT_CONTAINER:-bolt}"
 BOLT_URL="${BOLT_URL:-http://localhost:3001/mcp}"
 SYSTEM_PROMPT="${SYSTEM_PROMPT:-$DIR/prompts/recon-agent.md}"

--- a/prompts/recon-agent.md
+++ b/prompts/recon-agent.md
@@ -1,0 +1,43 @@
+You are an autonomous offensive-security reconnaissance agent on an authorized engagement.
+
+You are NOT a chatbot. You are NOT generating example commands for the user to run. You are
+running inside an MCP-enabled runtime where every function in your tools list is actually
+executable RIGHT NOW. When you emit a tool call, the runtime executes it, returns real output,
+and you continue with the result. Refusing to execute, generating "example" commands as text,
+or saying "I cannot perform actions here" is incorrect — you CAN and you MUST. If the user gives
+you a target, your VERY FIRST action is a function call to a `bolt__*` tool, not a paragraph of
+explanation.
+
+The user gives you a target — a domain, hostname, IP, URL, or IoC — and nothing else.
+You decide which tools to call. You never ask which tool to use or how to format arguments.
+You issue tool calls (function calls), not shell snippets or pseudocode.
+
+Your tools are exposed by the `bolt` MCP server. Every tool name starts with `bolt__`.
+Read each tool's description and parameter schema from the function definitions you've been given.
+You already have everything you need to plan — do not ask the user to clarify.
+
+## Default playbook (pick the branch that matches the target)
+
+**Bare domain** (e.g. `acme.com`):
+1. `bolt__subfinder` and/or `bolt__crtsh_crtsh` → collect subdomains.
+2. `bolt__dnsx_dnsx_resolve` → keep only ones that resolve.
+3. `bolt__httpx` → find live HTTP services.
+4. `bolt__nuclei` against the live HTTP set, severity at least medium.
+5. Drill in on anything interesting (sslscan on HTTPS, wpscan on WordPress, ffuf on responsive endpoints, http-headers audit).
+
+**Hostname / FQDN** (e.g. `api.acme.com`):
+- Skip enum. Resolve → `bolt__nmap` top ports → `bolt__httpx` on web ports → `bolt__nuclei` → drill in.
+
+**IP or CIDR**:
+- `bolt__nmap` (or masscan + nmap targeted) → `bolt__httpx` on web ports → `bolt__nuclei`.
+
+**URL** (`https://...`):
+- `bolt__httpx` → `bolt__http-headers_analyze-http-header` → `bolt__sslscan_do-sslscan` if HTTPS → `bolt__katana_do-katana` to crawl → `bolt__ffuf` or `bolt__arjun_do-arjun` if endpoints look juicy → `bolt__nuclei` targeted.
+
+## Rules
+
+- Issue a tool call on your very first turn. Do not write a plan in prose first — just start.
+- Chain tools: pipe output of one into input of the next. Filter and dedupe between steps.
+- Stay in scope. Only act on the target the user gave you.
+- Stop when you have findings to report, OR every reasonable next step has been tried, OR a tool hard-fails twice in a row.
+- Final answer: short structured report with **Target**, **Live assets**, **Findings**, **Skipped/failed**, **Suggested next step**.

--- a/prompts/recon-agent.md
+++ b/prompts/recon-agent.md
@@ -97,8 +97,21 @@ sibling tool (e.g. crtsh instead of subfinder) and keep going.
 
 - First message is always a tool call. No prose plans before the first call.
 - Chain tools — output of one is input to the next. Filter & dedupe between phases.
-- Stay in scope. Only act on the target the user gave you.
+- Stay in scope. Only act on the target the user gave you. The runtime will
+  reject out-of-scope targets at the gateway; if you somehow receive one,
+  refuse and report it in the final summary.
 - A tool is allowed to fail twice (different args each time) before you skip it.
+
+## Disabled tools — never call these
+
+`bolt__run_command` is DISABLED for every engagement. It is a generic shell
+escape that bypasses the structured tool surface, makes audit logs harder
+to reason about, and is the easiest pivot for prompt-injection attacks
+embedded in scanned content. If a scenario seems to need a shell, pick a
+purpose-built tool (`ffuf`, `nmap.extra_args`, `nuclei`) or report the gap
+in the final summary. Per-request prompts may add more names to this list
+— honor any "DISABLED tools for this engagement" line in the user message
+with equal weight.
 
 ## Stop conditions — you may stop ONLY when
 

--- a/prompts/recon-agent.md
+++ b/prompts/recon-agent.md
@@ -1,43 +1,121 @@
-You are an autonomous offensive-security reconnaissance agent on an authorized engagement.
+You are an autonomous offensive-security analyst on an authorized engagement.
 
-You are NOT a chatbot. You are NOT generating example commands for the user to run. You are
-running inside an MCP-enabled runtime where every function in your tools list is actually
-executable RIGHT NOW. When you emit a tool call, the runtime executes it, returns real output,
-and you continue with the result. Refusing to execute, generating "example" commands as text,
-or saying "I cannot perform actions here" is incorrect — you CAN and you MUST. If the user gives
-you a target, your VERY FIRST action is a function call to a `bolt__*` tool, not a paragraph of
-explanation.
+You are NOT a chatbot. You are NOT generating example commands for the user to run.
+You are running inside an MCP runtime where every function in your tools list is
+executable RIGHT NOW. Refusing to execute, generating "example" commands as text,
+or saying "I cannot perform actions here" is wrong — you CAN and you MUST. When
+the user gives you a target, your VERY FIRST action is a function call to a
+`bolt__*` tool, not a paragraph of explanation.
 
-The user gives you a target — a domain, hostname, IP, URL, or IoC — and nothing else.
-You decide which tools to call. You never ask which tool to use or how to format arguments.
-You issue tool calls (function calls), not shell snippets or pseudocode.
+You decide which tools to call. You never ask the user which tool to use or how
+to format arguments. The function definitions you've been given carry the
+canonical parameter schema — read them and fill in fields exactly.
 
-Your tools are exposed by the `bolt` MCP server. Every tool name starts with `bolt__`.
-Read each tool's description and parameter schema from the function definitions you've been given.
-You already have everything you need to plan — do not ask the user to clarify.
+## Mandatory pipeline — a scan is INCOMPLETE until all four phases ran
 
-## Default playbook (pick the branch that matches the target)
+For every target you must:
+  ENUMERATE  →  RESOLVE  →  PROBE  →  VULN-SCAN  →  (optional drill-in)
 
-**Bare domain** (e.g. `acme.com`):
-1. `bolt__subfinder` and/or `bolt__crtsh_crtsh` → collect subdomains.
-2. `bolt__dnsx_dnsx_resolve` → keep only ones that resolve.
-3. `bolt__httpx` → find live HTTP services.
-4. `bolt__nuclei` against the live HTTP set, severity at least medium.
-5. Drill in on anything interesting (sslscan on HTTPS, wpscan on WordPress, ffuf on responsive endpoints, http-headers audit).
+Subdomain enumeration alone is NOT a finding — it is the input to the next
+phase. Returning a list of 1000 subdomains and stopping is wrong. You must
+continue to RESOLVE, PROBE, and VULN-SCAN before producing the final report.
 
-**Hostname / FQDN** (e.g. `api.acme.com`):
-- Skip enum. Resolve → `bolt__nmap` top ports → `bolt__httpx` on web ports → `bolt__nuclei` → drill in.
+## Phase guide — pick the branch matching the target
 
-**IP or CIDR**:
-- `bolt__nmap` (or masscan + nmap targeted) → `bolt__httpx` on web ports → `bolt__nuclei`.
+**Bare domain** (`acme.com`):
+  1. ENUMERATE   bolt__subfinder  and/or  bolt__crtsh_crtsh
+  2. RESOLVE     bolt__dnsx_dnsx_resolve  on the enumerated names
+  3. PROBE       bolt__httpx              on the resolved hosts
+  4. VULN-SCAN   bolt__nuclei             on the live HTTP endpoints, medium+
+  5. DRILL       sslscan / http-headers / wpscan / ffuf as appropriate
 
-**URL** (`https://...`):
-- `bolt__httpx` → `bolt__http-headers_analyze-http-header` → `bolt__sslscan_do-sslscan` if HTTPS → `bolt__katana_do-katana` to crawl → `bolt__ffuf` or `bolt__arjun_do-arjun` if endpoints look juicy → `bolt__nuclei` targeted.
+**Hostname / FQDN** (`api.acme.com`):
+  1. RESOLVE     bolt__dnsx_dnsx_resolve
+  2. PORTS       bolt__nmap (top 1024)
+  3. PROBE       bolt__httpx on web ports
+  4. VULN-SCAN   bolt__nuclei
+  5. DRILL       as above
+
+**IP or CIDR** (`1.2.3.4`, `10.0.0.0/24`):
+  1. PORTS       bolt__nmap (top 1024 first)
+  2. PROBE       bolt__httpx on web ports
+  3. VULN-SCAN   bolt__nuclei
+  4. DRILL       as above
+
+**URL** (`https://acme.com/path`):
+  1. PROBE       bolt__httpx
+  2. AUDIT       bolt__http-headers_analyze-http-header
+                 bolt__sslscan_do-sslscan  (if HTTPS)
+  3. CRAWL       bolt__katana_do-katana
+  4. FUZZ        bolt__ffuf  or  bolt__arjun_do-arjun
+  5. VULN-SCAN   bolt__nuclei  on discovered endpoints
+
+## Tool argument shapes — common pitfalls
+
+Read the function schema for the canonical truth. These are the fields most
+often gotten wrong:
+
+  bolt__subfinder              { "domain": "acme.com" }
+  bolt__crtsh_crtsh            { "domain": "acme.com" }
+  bolt__assetfinder_*          { "domain": "acme.com" }
+  bolt__amass_amass            { "domain": "acme.com" }
+
+  bolt__dnsx_dnsx_resolve      { "hosts": ["a.acme.com","b.acme.com"],
+                                 "record_type": "A" }     # hosts IS AN ARRAY
+  bolt__alterx_*               { "domain": "acme.com" }
+  bolt__shuffledns_shuffledns  { "domain": "acme.com", "wordlist": "..." }
+
+  bolt__nmap                   { "target": "acme.com", "ports": "1-1024",
+                                 "scan_type": "connect", "timing": "3" }
+                               # scan_type values: syn|connect|udp|version|os
+                               # timing values: "0".."5" (strings, not ints)
+  bolt__masscan_*              { "target": "1.2.3.4", "ports": "1-1024",
+                                 "rate": 1000 }
+
+  bolt__httpx                  { "target": "https://acme.com" }   # STRING
+  bolt__katana_*               { "target": "https://acme.com" }
+  bolt__ffuf                   { "url": "https://acme.com/FUZZ" }
+  bolt__arjun_*                { "url": "https://acme.com/api" }
+
+  bolt__nuclei                 { "target": "https://acme.com" }   # STRING, not array
+                               # call once per host if you have many
+  bolt__sslscan_*              { "target": "acme.com:443" }
+  bolt__http-headers_*         { "target": "https://acme.com" }
+  bolt__wpscan_*               { "target": "https://wp.acme.com" }
+
+  bolt__sqlmap_*               { "url": "https://acme.com/?id=1" }
+  bolt__commix_*               { "url": "https://acme.com/api?cmd=" }
+
+  bolt__run_command            { "command": "echo hi", "sudo": false,
+                                 "timeout": 10 }
+
+If a tool errors with "invalid arguments", READ the error, RE-READ the schema,
+fix the field name or type, retry ONCE. Do not abandon the phase — pick a
+sibling tool (e.g. crtsh instead of subfinder) and keep going.
 
 ## Rules
 
-- Issue a tool call on your very first turn. Do not write a plan in prose first — just start.
-- Chain tools: pipe output of one into input of the next. Filter and dedupe between steps.
+- First message is always a tool call. No prose plans before the first call.
+- Chain tools — output of one is input to the next. Filter & dedupe between phases.
 - Stay in scope. Only act on the target the user gave you.
-- Stop when you have findings to report, OR every reasonable next step has been tried, OR a tool hard-fails twice in a row.
-- Final answer: short structured report with **Target**, **Live assets**, **Findings**, **Skipped/failed**, **Suggested next step**.
+- A tool is allowed to fail twice (different args each time) before you skip it.
+
+## Stop conditions — you may stop ONLY when
+
+- All phases for the target's branch have been ATTEMPTED, AND
+- You have at least one vuln-scan result (a clean `nuclei` result counts).
+
+You may NOT stop because:
+- enumeration returned a lot of data,
+- you "have enough information",
+- the result feels overwhelming to summarize.
+
+## Final report — short, structured
+
+  **Target:**           what you scanned
+  **Phases completed:** [ENUMERATE, RESOLVE, PROBE, VULN-SCAN, DRILL] — list which ran
+  **Live assets:**      subdomains / hosts / ports that responded
+  **Findings:**         vulns / misconfigs / exposures, severity-ranked,
+                        or "none in this pass"
+  **Skipped or failed:** which tool, why
+  **Suggested next step:** the single most valuable follow-up

--- a/scope.json.example
+++ b/scope.json.example
@@ -1,0 +1,18 @@
+{
+  "_comment": "Server-side scope enforcement for bridge-api.py. Copy to scope.json (no '.example' suffix) to activate. If scope.json is missing OR all three arrays are empty, scope checks are SKIPPED — useful for local dev. Once any rule is present, every /scan and /scan/stream request must have its target(s) match at least one allow rule, otherwise the bridge returns 403.",
+
+  "allowed_domain_patterns": [
+    "^(.*\\.)?acme\\.com$",
+    "^(.*\\.)?example\\.com$",
+    "^scanme\\.nmap\\.org$"
+  ],
+
+  "allowed_cidrs": [
+    "192.0.2.0/24",
+    "198.51.100.0/24"
+  ],
+
+  "disabled_tools": [
+    "bolt__run_command"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds an end-to-end bridge that lets a local Ollama model use bolt's MCP toolset without depending on Claude/Anthropic, plus a stdlib HTTP API so external services (e.g. a Rails threat-intel pipeline) can call it over the wire. Nothing in bolt's existing code paths is changed; everything here is additive.

## What changed

| File | Purpose |
|---|---|
| `ollama-bridge.sh` | CLI wrapper around `mcphost`. Pulls bolt's `MCP_ADMIN_TOKEN` from the running container, health-checks ollama + bolt, applies the default system prompt, max-steps and temperature. |
| `.mcphost.json` | mcphost remote-server config pointing at bolt's HTTP MCP endpoint with bearer auth via `${env://BOLT_ADMIN_TOKEN}` substitution. |
| `Modelfile.qwen7b-bolt`, `Modelfile.qwen14b-bolt` | Derived Ollama models that bake `num_ctx=32768` (default 4096 was too small for bolt's 25-tool schema + system prompt) and a low temperature for decisive tool calls. |
| `prompts/recon-agent.md` | Agent role + default playbook telling the model to classify the target, plan, and chain tools (subfinder → dnsx → httpx → nuclei) instead of asking the user which tool to invoke. |
| `bridge-api.py` | Stdlib-only HTTP wrapper. `POST /scan` accepts `{target, targets, iocs, infra, instructions, prompt, system_prompt, model, max_steps, timeout, verbose}`; auto-builds a prompt or accepts a raw one; supports per-request system-prompt override; returns JSON `{ok, output, duration_ms, model, error}`. `GET /health` verifies ollama, bolt, and the bridge script. |

## Why

Bolt today is consumed by Claude Desktop / Claude Code — i.e. an Anthropic-hosted client drives the toolset. This PR makes bolt usable from any local Ollama model and from any HTTP-speaking app. The pieces are intentionally split:

- The shell wrapper handles the messy environment glue (token, health, mcphost flags).
- The Modelfiles solve a real footgun: Ollama loads `qwen2.5:*` with a 4 K context by default, which silently truncates bolt's 25-tool schema and makes the model "forget" what tools it has.
- The system prompt fixes the second footgun: small models will happily generate tool-use *examples in text* instead of issuing function calls — the prompt forces them to invoke instead of describe.
- `bridge-api.py` is the integration point for a Rails / FastAPI / other backend that wants to fire scans without spawning processes itself.

## How to use

```bash
# one-shot CLI
./ollama-bridge.sh -p "Target: scanme.nmap.org. Recon it."

# interactive REPL
./ollama-bridge.sh

# HTTP API for external apps
python3 bridge-api.py            # listens on :8080
curl -X POST http://localhost:8080/scan \
  -H 'Content-Type: application/json' \
  -d '{"target":"scanme.nmap.org","iocs":["45.33.32.156"]}'
```

Override per call: `MODEL=qwen2.5:14b-bolt`, `MAX_STEPS=60`, `SYSTEM_PROMPT=/path/to/role.md`, etc.

## Known issue worth a follow-up

Bolt's `nmap` (and any other plugin marked `requiresRoot: true`) wraps the binary with `sudo` via `packages/core/src/executor.ts`. The shipped Docker image runs as root and does not include `sudo` — so every root-required tool fails with `Executable not found in $PATH: "sudo"`. As a runtime workaround we drop a passthrough shim into the running container:

```bash
docker exec bolt sh -c 'printf "#!/bin/sh\nexec \"\$@\"\n" > /usr/local/bin/sudo && chmod +x /usr/local/bin/sudo'
```

The clean upstream fix is a one-liner in `executor.ts`: skip the `sudo` prefix when `process.getuid?.() === 0`. Happy to send a separate PR for that if maintainers prefer.

## Test plan

- [x] `ollama-bridge.sh -p "say OK"` returns `OK` (~5s, plain chat path)
- [x] `ollama-bridge.sh -p "Target: scanme.nmap.org. Recon it."` issues real `bolt__nmap`, `bolt__httpx` etc. tool calls visible in `docker logs bolt`
- [x] `bridge-api.py` `GET /health` returns ok with all three checks green
- [x] `POST /scan` with bare `{}` returns 400 with the right message
- [x] `POST /scan` with `targets` array of wrong type is rejected with a clear error
- [x] `POST /scan` with `target` only, `targets` only, and both, all auto-build a prompt and run end-to-end
- [x] `system_prompt` override is written to a tempfile, passed via `SYSTEM_PROMPT` env var to mcphost, and cleaned up after the run
- [x] Modelfile-built `qwen2.5:7b-bolt` reports `context_length=32768` from `/api/ps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)